### PR TITLE
Feature: RTL Support

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,14 +10,15 @@
           'full-screen': !showCustomList,
           'hidden-lists-container': hideTopListContainer,
           'full-screen-divider': hideBottomListContainer,
+          'rtl': isRTL,
         }">
-          <i class="bi-chevron-left slider-btn" ref="weekLeft" @click="weekMoveLeft"></i>
+          <i class="bi-chevron-left slider-btn" ref="weekLeft" @click="isRTL ? weekMoveRight() : weekMoveLeft()"></i>
           <div class="todo-slider" ref="weekListContainer">
             <to-do-list v-for="date in dates_array" :key="date" :id="date" :showCustomList="showCustomList"
               @todo-list-mounted="todoListMounted">
             </to-do-list>
           </div>
-          <i class="bi-chevron-right slider-btn" ref="weekRight" @click="weekMoveRight"></i>
+          <i class="bi-chevron-right slider-btn" ref="weekRight" @click="isRTL ? weekMoveLeft() : weekMoveRight()"></i>
         </div>
 
         <div v-show="showCustomList && showCalendar" class="main-horizontal-divider" id="resizer"
@@ -39,6 +40,7 @@
           'full-screen': !showCalendar,
           'flex-grow-1': showCalendar,
           'hidden-lists-container': hideBottomListContainer,
+          'rtl': isRTL,
         }">
           <i class="bi-chevron-left slider-btn" @click="customMoveLeft" :style="{
             visibility: cTodoList.length > customColumns ? 'visible' : 'hidden',
@@ -611,7 +613,9 @@ body {
   margin-bottom: 25px;
   // margin-bottom: 5px;
 }
-
+.todo-lists-container.rtl {
+  flex-direction: row-reverse;
+}
 .slider-btn {
   padding: 3px;
   font-size: 2rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <input class="hidden-input-for-focus" type="text" />
-  <div v-show="compatible" id="app-container" class="app-container" :class="{ 'dark-theme': darkTheme }">
+  <div v-show="compatible" id="app-container" class="app-container" :class="{ 'dark-theme': darkTheme, 'lang-rtl': isRTL }">
     <div class="hidden-mobile app-body" :style="{ zoom: `${zoom}%` }">
       <splash-screen ref="splash"></splash-screen>
       <side-bar @change-date="setSelectedDate"></side-bar>
@@ -549,6 +549,9 @@ export default {
     darkTheme: function () {
       return this.$store.getters.config.darkTheme;
     },
+    isRTL: function () {
+      return this.$i18n.locale === 'ar'
+    },
     resizableStyle: function () {
       if (this.showCalendar && this.showCustomList) {
         return { height: this.calendarHeight };
@@ -658,7 +661,9 @@ body {
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
 }
-
+.lang-rtl {
+  direction: rtl;
+}
 .dark-theme *::-webkit-scrollbar-thumb {
   background: #333940;
   border-radius: 5px;

--- a/src/components/layout/sideBar.vue
+++ b/src/components/layout/sideBar.vue
@@ -107,6 +107,7 @@ export default {
   flex-direction: column;
   float: left;
   background-color: #fcfcfc;
+  direction: ltr;
 }
 
 .side-bar i:first-child {

--- a/src/components/linkList.vue
+++ b/src/components/linkList.vue
@@ -1,13 +1,13 @@
 <template>
   <ul class="list-group">
-    <li v-for="item in linkList" :key="item" class="list-group-item">
+    <li v-for="item in linkList" :key="item" class="list-group-item" :class="{ 'rtl' : isRTL}">
       <div class="d-flex list-item justify-content-between" @click="linkAction(item.link,item.linktype)">
         <div class="item-img">
           <i v-if="item.ico" :style="'font-size: 24px; color: '+ item.color" :class="item.ico"></i>
           <img v-if="item.img" :src="item.img" height="24">
         </div>
         <div class="align-self-center w-100">{{item.name}}</div>
-        <i class="bi-chevron-right align-self-center"></i>
+        <i class="align-self-center" :class="isRTL ? 'bi-chevron-left' : 'bi-chevron-right'"></i>
       </div>
     </li>
   </ul>
@@ -52,6 +52,11 @@
             tagIdLink: function (id) {
                 document.getElementById(id).click();
             }
+        },
+        computed: {
+          isRTL: function () {
+            return this.$i18n.locale === 'ar'
+          },
         }
     }
 </script>
@@ -82,6 +87,10 @@
 
   .item-img {
     margin-right: 24px;
+  }
+  .list-group-item.rtl .list-item .item-img {
+    margin-right: 0;
+    margin-left: 24px;
   }
 
   .dark-theme .card {

--- a/src/views/configModal.vue
+++ b/src/views/configModal.vue
@@ -282,7 +282,7 @@
             <div class="tab-pane fade" id="config-language">
               <div class="d-flex flex-column mt-2 h-100">
                 <label for="language" class="form-label">{{ $t("settings.language") }}:</label>
-                <select id="language" class="col-sm-9 form-select" aria-label="Default select example"
+                <select id="language" class="col-sm-9 form-select" :class="{'rtl' : isRTL}" aria-label="Default select example"
                   v-model="configData.language" @change="setLanguage">
                   <option value="en">English</option>
                   <option value="es">Español</option>
@@ -422,6 +422,9 @@ export default {
     configLinks: function () {
       return configList.configList(this);
     },
+    isRTL: function () {
+      return this.$i18n.locale === 'ar'
+    },
     watch: {
       configProp: function (newVal) {
         this.configData = newVal;
@@ -458,7 +461,9 @@ export default {
 .form-select:focus {
   box-shadow: none;
 }
-
+.form-select.rtl {
+  background-position: left .75rem center;
+}
 .modal-dialog {
   max-width: 320px;
   // height: 200px;

--- a/src/views/configModal.vue
+++ b/src/views/configModal.vue
@@ -293,7 +293,7 @@
                   <option value="ru">русский</option>
                   <option value="ja">日本</option>
                   <option value="pl">Polski</option>
-                  <option value="ar">عرب</option>
+                  <option value="ar">العربية</option>
                   <option value="ko">한국어</option>
                   <option value="zh_cn">简体中文</option>
                   <option value="zh_tw">繁體中文</option>

--- a/src/views/tipsModal.vue
+++ b/src/views/tipsModal.vue
@@ -9,13 +9,13 @@
         </div>
         <div class="modal-body d-flex">
           <div style="margin: 5px">
-            <i class="bi-info-circle" style="font-size: 38px; margin-right: 30px; "></i>
+            <i class="bi-info-circle" :class="{ 'rtl' : isRTL}" style="font-size: 38px;"></i>
           </div>
           <div style="margin-top: 9px">
             {{tips[index].text}}
           </div>
         </div>
-        <div class="modal-footer d-flex">
+        <div class="modal-footer d-flex" :class="{ 'rtl' : isRTL}">
           <button type="button" class="btn flex-fill" @click="back"><i class="bi-chevron-double-left"></i>
             {{$t('tips.back')}}
           </button>
@@ -71,7 +71,10 @@
                     {text: this.$i18n.t("tips.tip17")},
                     {text: this.$i18n.t("tips.tip18")},
                 ]
-            }
+            },
+            isRTL: function () {
+              return this.$i18n.locale === 'ar'
+            },
         }
     }
 </script>
@@ -84,13 +87,21 @@
   .modal-body {
     height: 100px;
   }
-
+  .modal-footer.rtl {
+    flex-direction: row-reverse;
+  }
+  .modal-footer .btn {
+    direction: ltr;
+  }
   .bi-info-circle {
     background: -webkit-linear-gradient(180deg, rgba(89, 66, 141, 1) 0%, rgba(114, 78, 156, 1) 90%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+    margin-right: 30px;
   }
-
+  .bi-info-circle.rtl {
+    margin-left: 30px;
+  }
   .dark-theme .bi-info-circle {
     background: -webkit-linear-gradient(180deg, rgb(115, 75, 176) 0%, rgb(147, 110, 203) 90%);
     -webkit-background-clip: text;


### PR DESCRIPTION
Changes:
- Switch the CSS direction to 'RTL' when the current language is Arabic
- Fixed the styling issues for RTL, including
  - Switching the right arrow icons to left, and vice versa
  - Switching the right margins to left, and vice versa
  - Setting the flex direction to `row-reverse` where needed

Please note that if any other RTL language added in the future, you'll have to edit this computed function
```js
isRTL: function () {
     return this.$i18n.locale === 'ar'
}
```
in 4 places: `App.vue`, `linkList.vue`, `configModal.vue`, and `tipsModal.vue`, to make it check for other RTL languages as well. Currently, it's just Arabic.